### PR TITLE
Enhanced description

### DIFF
--- a/CN1Libs.xml
+++ b/CN1Libs.xml
@@ -39,7 +39,7 @@
     
     <plugin fileName="VideoOptimizerCN1Lib.cn1lib">
         <name>Video Optimizer</name>
-        <description>It allows to get info about a video, get a preview image of a video and optimize a video for fast upload.</description>
+        <description>It allows to get info about a video (duration, bitrate, size), get a preview image of a video and optimize a video for fast upload. It can also be used to check if a given file is a supported video.</description>
         <link>https://github.com/jsfan3/CN1Libs-VideoOptimizer/</link>
         <version>2</version>
         <license>CC0 + LGPL v.3</license>


### PR DESCRIPTION
Motivation:
Checking that a file is a valid supported video was an undocumented feature, I added a code tip here: https://github.com/jsfan3/CN1Libs-VideoOptimizer#tip-check-if-a-given-file-is-a-supported-video
Note that the CN1 method `Util.guessMimeType(...)` doesn't support video mime types: the same lack of video mime types is an issue of Oracle Java 13 and of Android SDK 28 API, that's why checking that a file is a valid supported video (regardless the extension) is not as easy as it can seems.